### PR TITLE
Fix url for db.connect()

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -5,7 +5,7 @@ var MONGO_URL = process.env.MONGOHQ_URL || 'localhost/rtvote';
 if (process.env.NODE_ENV === 'test') {
   MONGO_URL = 'localhost/rtvote-test';
 }
-db.connect(process.env.MONGOHQ_URL || 'localhost/rtvote', function(err) {
+db.connect(MONGO_URL, function(err) {
   if (err) {
     throw err;
   }


### PR DESCRIPTION
db could't connect to 'localhost/rtvote-test' when
development mode which is 'NODE_ENV=test'.

I fixed url for db.connect() in order to connect to
'localhot/rtvote-test' when development mode.
